### PR TITLE
Updates nov18

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@ledgerhq/live-common": "4.2.1",
+    "@ledgerhq/live-common": "4.5.0",
     "axios": "^0.18.0",
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.2.6",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "flow-typed": "flow-typed install -s"
   },
   "name": "ledger-api-countervalue-nodejs",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "MIT",
   "private": true,
   "dependencies": {

--- a/src/db/mongodb.js
+++ b/src/db/mongodb.js
@@ -56,7 +56,6 @@ const metaId = "meta_1";
 async function setMeta(meta) {
   const client = await getDB();
   const db = client.db();
-  console.log("setMeta", meta);
   await promisify(
     db.collection("meta"),
     "updateOne",
@@ -187,6 +186,7 @@ async function queryExchanges() {
 
 const queryPairExchangesSortCursor = cursor =>
   cursor.sort({
+    hasHistoryFor1Year: -1,
     yesterdayVolume: -1
   });
 

--- a/src/db/mongodb.js
+++ b/src/db/mongodb.js
@@ -51,6 +51,41 @@ const init = async () => {
   );
 };
 
+const metaId = "meta_1";
+
+async function setMeta(meta) {
+  const client = await getDB();
+  const db = client.db();
+  console.log("setMeta", meta);
+  await promisify(
+    db.collection("meta"),
+    "updateOne",
+    { id: metaId },
+    {
+      $set: meta
+    },
+    { upsert: true }
+  );
+}
+
+async function getMeta() {
+  const client = await getDB();
+  const db = client.db();
+  const { id, _id, ...meta } = await promisify(
+    db.collection("meta"),
+    "findOne",
+    {
+      id: metaId
+    }
+  );
+  console.log({ meta });
+  return {
+    lastLiveRatesSync: new Date(0),
+    lastMarketCapSync: new Date(0),
+    ...meta
+  };
+}
+
 async function statusDB() {
   const client = await getDB();
   const db = client.db();
@@ -78,6 +113,7 @@ async function updateLiveRates(all) {
       )
     )
   );
+  await setMeta({ lastLiveRatesSync: new Date() });
 }
 
 async function updateHistodays(id, histodays) {
@@ -138,6 +174,7 @@ async function updateMarketCapCoins(day, coins) {
       upsert: true
     }
   );
+  await setMeta({ lastMarketCapSync: new Date() });
 }
 
 async function queryExchanges() {
@@ -204,6 +241,7 @@ const queryMarketCapCoinsForDay = async day => {
 
 const database: Database = {
   init,
+  getMeta,
   statusDB,
   updateLiveRates,
   updateHistodays,

--- a/src/sync.js
+++ b/src/sync.js
@@ -2,8 +2,12 @@
 // Synchronize the local database with distant service
 import "./nodeCrashOnUncaught";
 import { getCurrentDatabase } from "./db";
-import { prefetchAllPairExchanges, pullLiveRates } from "./cache";
-import { pullLiveRatesError, pullLiveRatesEnd } from "./logger";
+import {
+  prefetchAllPairExchanges,
+  pullLiveRates,
+  getDailyMarketCapCoins
+} from "./cache";
+import { pullLiveRatesError, pullLiveRatesEnd, log, logError } from "./logger";
 import { recurrentJob } from "./utils";
 
 const rebootTimeIfError = 60 * 1000;
@@ -15,6 +19,10 @@ getCurrentDatabase()
   .init()
   .then(() => {
     function pullLoop() {
+      getDailyMarketCapCoins().catch(e =>
+        logError("marketcap failed to fetch", e)
+      );
+
       const sub = pullLiveRates(
         error => {
           pullLiveRatesError(error);

--- a/src/types.js
+++ b/src/types.js
@@ -115,6 +115,8 @@ export type Database = {
     pairExchangeId: string,
     stats: {
       yesterdayVolume?: number,
+      hasHistoryFor1Year?: boolean,
+      oldestDayAgo?: number,
       hasHistoryFor30LastDays?: boolean,
       historyLoadedAtDay?: string,
       latestDate?: Date
@@ -160,6 +162,8 @@ export type DB_PairExchangeData = {|
   // some derivated stats:
   latestDate: ?Date,
   yesterdayVolume: number, // the volume that was traded yesterday
+  oldestDayAgo: number,
+  hasHistoryFor1Year: boolean,
   hasHistoryFor30LastDays: boolean, // track if the histodays are available for the last 30 days
   historyLoadedAtDay: ?string // YYYY-MM-DD date where the histodays was loaded
 |};

--- a/src/types.js
+++ b/src/types.js
@@ -88,8 +88,15 @@ export type Provider = {
 };
 // Database types
 
+export type DBMeta = {
+  lastLiveRatesSync: Date,
+  lastMarketCapSync: Date
+};
+
 export type Database = {
   init: () => Promise<void>,
+
+  getMeta: () => Promise<DBMeta>,
 
   statusDB: () => Promise<void>,
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@aeternity/ledger-app-api@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@aeternity/ledger-app-api/-/ledger-app-api-0.0.4.tgz#79d253b46cc6b0b18ef7cb57c3684bbe7e723c51"
+  integrity sha512-aXvCJX9fdT/EJbRKBdc2mu8fvvWu80A8JyFdfvS4bsaDOGjBaIfFFYbEpxaXef8TBE5zV8u7RN1PaXDPGeDUZg==
+  dependencies:
+    "@ledgerhq/hw-transport" "^4.21.0"
+
 "@babel/code-frame@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz#2a02643368de80916162be70865c97774f3adbd9"
@@ -125,29 +132,31 @@
     "@ledgerhq/hw-transport" "^4.24.0"
     bip32-path "0.4.2"
 
-"@ledgerhq/hw-transport@^4.24.0":
+"@ledgerhq/hw-transport@^4.21.0", "@ledgerhq/hw-transport@^4.24.0":
   version "4.24.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.24.0.tgz#8def925d8c2e1f73d15128d9e27ead729870be58"
   integrity sha512-L34TG1Ss7goRB+5BxtvBwUuu0CmDSIxS33oUqkpEy6rCs31k7XicV48iUGAnRnt8hNY2DvJ9WFyaOroUE9h6wQ==
   dependencies:
     events "^3.0.0"
 
-"@ledgerhq/live-common@4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-4.2.1.tgz#935fb0990e28c9a43aab37f350a158ddc208c50a"
-  integrity sha512-acAXrlE8O0QbKqe0GG44USW2tnOOghZ37U+7OmkHTLCPtDm8ODgcbcwSAeHuetS+s//N8bt3uh1lyfD2R7GHRA==
+"@ledgerhq/live-common@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-4.5.0.tgz#74942df1c33763abf4dd9cf3b1e3632f91cd6611"
+  integrity sha512-5+cpCvpij2cYa8oSDi5sj4vvN+07Fxxlrcv4jp0B4aEXQRPqvbg2oveSR7y3La5TeGaxILt/RfathriTUIi1jw==
   dependencies:
+    "@aeternity/ledger-app-api" "0.0.4"
     "@ledgerhq/hw-app-btc" "^4.24.0"
     "@ledgerhq/hw-app-eth" "^4.24.0"
     "@ledgerhq/hw-app-xrp" "^4.24.0"
     "@ledgerhq/hw-transport" "^4.24.0"
     bignumber.js "^7.2.1"
+    compressjs gre/compressjs#hermit
     eip55 "^1.0.3"
     invariant "^2.2.2"
     lodash "^4.17.4"
-    node-lzw "^0.3.1"
     numeral "^2.0.6"
     prando "^3.0.1"
+    react "*"
     react-i18next "^8.0.7"
     react-redux "^5.0.7"
     redux "^4.0.0"
@@ -1280,6 +1289,13 @@ commander@^2.11.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
   integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
 
+commander@~2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
+  integrity sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
 component-bind@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"
@@ -1294,6 +1310,12 @@ component-inherit@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
   integrity sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=
+
+compressjs@gre/compressjs#hermit:
+  version "1.2.0"
+  resolved "https://codeload.github.com/gre/compressjs/tar.gz/19652f100671e559d7731980c26cd06a7e999b8d"
+  dependencies:
+    commander "~2.8.1"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -2086,6 +2108,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+  integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
+
 gud@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
@@ -2831,11 +2858,6 @@ node-fetch@^2.1.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
   integrity sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==
 
-node-lzw@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/node-lzw/-/node-lzw-0.3.1.tgz#f50e37968976aca83320028b91f101df4a436b2d"
-  integrity sha1-9Q43lol2rKgzIAKLkfEB30pDay0=
-
 node-pre-gyp@^0.9.0:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.9.1.tgz#f11c07516dd92f87199dbc7e1838eab7cd56c9e0"
@@ -3162,6 +3184,14 @@ prop-types@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 proxy-addr@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.3.tgz#355f262505a621646b3130a728eb647e22055341"
@@ -3259,6 +3289,16 @@ react-redux@^5.0.7:
     lodash-es "^4.17.5"
     loose-envify "^1.1.0"
     prop-types "^15.6.0"
+
+react@*:
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.6.3.tgz#25d77c91911d6bbdd23db41e70fb094cc1e0871c"
+  integrity sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.11.2"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -3524,6 +3564,14 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+scheduler@^0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.11.2.tgz#a8db5399d06eba5abac51b705b7151d2319d33d3"
+  integrity sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 "semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.5.0:
   version "5.5.0"


### PR DESCRIPTION
- Fixes #20 : new version of `GET /status` and  `GET /status/sync`
- Fixes #21 : exchange pairs that have less than 1 year of history will be sorted AFTER the one with 1 year +
- bump live-common (more tickers supported)